### PR TITLE
Distinguish between BWAIndex types when touch DONE

### DIFF
--- a/src/Modules/indexing/BWAIndex.java
+++ b/src/Modules/indexing/BWAIndex.java
@@ -86,5 +86,14 @@ public class BWAIndex extends AModule {
         }
     }
 
-
+    @Override
+    public String getModulename() {
+        switch (currentconf) {
+            case DEFAULT:
+                return this.getClass().getSimpleName();
+            case MT:
+                return this.getClass().getSimpleName() + ".MT";
+        }
+        return this.getClass().getSimpleName();
+    }
 }

--- a/src/Modules/mapping/CircularMapperRealigner.java
+++ b/src/Modules/mapping/CircularMapperRealigner.java
@@ -54,7 +54,7 @@ public class CircularMapperRealigner extends AModule{
     private void getFilteredParameters() {
         String output_stem = Files.getNameWithoutExtension(this.inputfile.get(0));
         this.parameters = new String[]{"realignsamfile", "-e",String.valueOf(this.communicator.getCM_elongationfac()), "-i",
-                this.inputfile.get(0), "-r", this.communicator.getGUI_reference(), "-f", "true"};
+                this.inputfile.get(0), "-r", this.communicator.getGUI_reference(), "-f", "true", "-x", "false"};
         this.communicator.setCM_referencemt_elong(this.communicator.getGUI_reference() + "_" + this.communicator.getCM_elongationfac() + ".fa");
         this.communicator.setCM_realigned(getOutputfolder()+"/"+output_stem+"_realigned.bam");
         this.outputfile = new ArrayList<>();


### PR DESCRIPTION
use -x false with realignsamfile to preserve reference headers
This should fix bwa index not being run for elongated MT.
Should also prevent downstream programs from failing when references in the fasta file are not found in BAM headers.
