### PR TITLE
Add clean sam after all mapping steps

### DIFF
--- a/src/Modules/filehandling/CleanSam.java
+++ b/src/Modules/filehandling/CleanSam.java
@@ -11,15 +11,27 @@ import java.util.ArrayList;
  */
 public class CleanSam extends AModule {
 
+    public static final int DEFAULT = 0;
+    public static final int SET_UNMAPPED_MAPQ_TO_ZERO_ONLY = 1;
+    private int currentconfiguration = DEFAULT;
+
     public CleanSam(Communicator c) {
         super(c);
+    }
+    public CleanSam(Communicator c, int configuration) {
+        super(c);
+        this.currentconfiguration = configuration;
     }
 
     @Override
     public void setParameters() {
         String output_stem = Files.getNameWithoutExtension(this.inputfile.get(0));
         String output = getOutputfolder()+"/"+output_stem+".cleaned.bam";
-        this.parameters = new String[]{"picard", "CleanSam", "INPUT="+this.inputfile.get(0), "OUTPUT="+ output};
+        if ( this.currentconfiguration == SET_UNMAPPED_MAPQ_TO_ZERO_ONLY ) {
+            this.parameters = new String[]{"CleanSamUnmappedOnly", this.inputfile.get(0), output};
+        } else {
+            this.parameters = new String[]{"picard", "CleanSam", "INPUT="+this.inputfile.get(0), "OUTPUT="+ output};
+        }
         this.outputfile = new ArrayList<>();
         this.outputfile.add(output);
     }

--- a/src/Runner/RunEAGER.java
+++ b/src/Runner/RunEAGER.java
@@ -152,6 +152,7 @@ public class RunEAGER {
                 bacterialpool.addModule(new BWAIndex(communicator));
             }
             addCircularMapping(bacterialpool);
+            bacterialpool.addModule(new CleanSam(communicator, CleanSam.SET_UNMAPPED_MAPQ_TO_ZERO_ONLY));
         }
 
 
@@ -161,6 +162,7 @@ public class RunEAGER {
                 bacterialpool.addModule(new BWAIndex(communicator));
             }
             addBWAMapping(bacterialpool);
+            bacterialpool.addModule(new CleanSam(communicator, CleanSam.SET_UNMAPPED_MAPQ_TO_ZERO_ONLY));
         }
 
         if (communicator.isRun_mapping() && communicator.getMapper_to_use().equals("Bowtie 2")) {
@@ -169,6 +171,7 @@ public class RunEAGER {
                 bacterialpool.addModule(new BT2Index(communicator));
             }
             addBT2Mapping(bacterialpool);
+            bacterialpool.addModule(new CleanSam(communicator, CleanSam.SET_UNMAPPED_MAPQ_TO_ZERO_ONLY));
         }
 
         if (communicator.isRun_mapping() && communicator.getMapper_to_use().equals("Stampy")) {
@@ -178,6 +181,7 @@ public class RunEAGER {
                 bacterialpool.addModule(new StampyHash(communicator));
             }
             addStampyMapping(bacterialpool);
+            bacterialpool.addModule(new CleanSam(communicator, CleanSam.SET_UNMAPPED_MAPQ_TO_ZERO_ONLY));
         }
 
         if (communicator.isRun_mapping() && communicator.getMapper_to_use().equals("BWAMem")) {
@@ -186,6 +190,7 @@ public class RunEAGER {
                 bacterialpool.addModule(new BWAIndex(communicator));
             }
             addBWAMemMapping(bacterialpool);
+            bacterialpool.addModule(new CleanSam(communicator, CleanSam.SET_UNMAPPED_MAPQ_TO_ZERO_ONLY));
         }
 
         if (communicator.isRun_complexityestimation()) {
@@ -197,7 +202,6 @@ public class RunEAGER {
         }
 
         if (communicator.isMarkdup_run()) {
-            bacterialpool.addModule(new CleanSam(communicator));
             bacterialpool.addModule(new MarkDuplicates(communicator));
         }
 
@@ -300,6 +304,7 @@ public class RunEAGER {
                 ancientbacterialpool.addModule(new BWAIndex(communicator));
             }
             addCircularMapping(ancientbacterialpool);
+            ancientbacterialpool.addModule(new CleanSam(communicator, CleanSam.SET_UNMAPPED_MAPQ_TO_ZERO_ONLY));
         }
 
         if (communicator.isRun_mapping() && communicator.getMapper_to_use().equals("BWA")) {
@@ -308,6 +313,7 @@ public class RunEAGER {
                 ancientbacterialpool.addModule(new BWAIndex(communicator));
             }
             addBWAMapping(ancientbacterialpool);
+            ancientbacterialpool.addModule(new CleanSam(communicator, CleanSam.SET_UNMAPPED_MAPQ_TO_ZERO_ONLY));
         }
 
         if (communicator.isRun_mapping() && communicator.getMapper_to_use().equals("Stampy")) {
@@ -317,6 +323,7 @@ public class RunEAGER {
                 ancientbacterialpool.addModule(new StampyHash(communicator));
             }
             addStampyMapping(ancientbacterialpool);
+            ancientbacterialpool.addModule(new CleanSam(communicator, CleanSam.SET_UNMAPPED_MAPQ_TO_ZERO_ONLY));
         }
 
         if (communicator.isRun_mapping() && communicator.getMapper_to_use().equals("Bowtie 2")) {
@@ -325,6 +332,7 @@ public class RunEAGER {
                 ancientbacterialpool.addModule(new BT2Index(communicator));
             }
             addBT2Mapping(ancientbacterialpool);
+            ancientbacterialpool.addModule(new CleanSam(communicator, CleanSam.SET_UNMAPPED_MAPQ_TO_ZERO_ONLY));
         }
 
         if (communicator.isRun_mapping() && communicator.getMapper_to_use().equals("BWAMem")) {
@@ -333,6 +341,7 @@ public class RunEAGER {
                 ancientbacterialpool.addModule(new BWAIndex(communicator));
             }
             addBWAMemMapping(ancientbacterialpool);
+            ancientbacterialpool.addModule(new CleanSam(communicator, CleanSam.SET_UNMAPPED_MAPQ_TO_ZERO_ONLY));
         }
 
         if (communicator.isRun_complexityestimation()) {
@@ -345,7 +354,6 @@ public class RunEAGER {
         }
 
         if (communicator.isMarkdup_run()) {
-            ancientbacterialpool.addModule(new CleanSam(communicator));
             ancientbacterialpool.addModule(new MarkDuplicates(communicator));
         }
 
@@ -448,6 +456,7 @@ public class RunEAGER {
                 humanmodernpool.addModule(new BWAIndex(communicator));
             }
             addBWAMapping(humanmodernpool);
+            humanmodernpool.addModule(new CleanSam(communicator, CleanSam.SET_UNMAPPED_MAPQ_TO_ZERO_ONLY));
         }
 
         if (communicator.isRun_mapping() && communicator.getMapper_to_use().equals("Stampy")) {
@@ -457,6 +466,7 @@ public class RunEAGER {
                 humanmodernpool.addModule(new StampyHash(communicator));
             }
             addStampyMapping(humanmodernpool);
+            humanmodernpool.addModule(new CleanSam(communicator, CleanSam.SET_UNMAPPED_MAPQ_TO_ZERO_ONLY));
         }
 
         if (communicator.isRun_mapping() && communicator.getMapper_to_use().equals("BWAMem")) {
@@ -465,6 +475,7 @@ public class RunEAGER {
                 humanmodernpool.addModule(new BWAIndex(communicator));
             }
             addBWAMemMapping(humanmodernpool);
+            humanmodernpool.addModule(new CleanSam(communicator, CleanSam.SET_UNMAPPED_MAPQ_TO_ZERO_ONLY));
         }
 
         if (communicator.isRun_mapping() && communicator.getMapper_to_use().equals("Bowtie 2")) {
@@ -473,6 +484,7 @@ public class RunEAGER {
                 humanmodernpool.addModule(new BT2Index(communicator));
             }
             addBT2Mapping(humanmodernpool);
+            humanmodernpool.addModule(new CleanSam(communicator, CleanSam.SET_UNMAPPED_MAPQ_TO_ZERO_ONLY));
         }
 
         if (communicator.isRun_mapping() && communicator.getMapper_to_use().equals("CircularMapper")) {
@@ -481,6 +493,7 @@ public class RunEAGER {
                 humanmodernpool.addModule(new BWAIndex(communicator));
             }
             addCircularMapping(humanmodernpool);
+            humanmodernpool.addModule(new CleanSam(communicator, CleanSam.SET_UNMAPPED_MAPQ_TO_ZERO_ONLY));
         }
 
         if (communicator.isRun_complexityestimation()) {
@@ -492,7 +505,6 @@ public class RunEAGER {
         }
 
         if (communicator.isMarkdup_run()) {
-            humanmodernpool.addModule(new CleanSam(communicator));
             humanmodernpool.addModule(new MarkDuplicates(communicator));
         }
 
@@ -612,6 +624,7 @@ public class RunEAGER {
                 humanancientpool.addModule(new BWAIndex(communicator));
             }
             addBWAMapping(humanancientpool);
+            humanancientpool.addModule(new CleanSam(communicator, CleanSam.SET_UNMAPPED_MAPQ_TO_ZERO_ONLY));
         }
 
         if (communicator.isRun_mapping() && communicator.getMapper_to_use().equals("Stampy")) {
@@ -621,6 +634,7 @@ public class RunEAGER {
                 humanancientpool.addModule(new StampyHash(communicator));
             }
             addStampyMapping(humanancientpool);
+            humanancientpool.addModule(new CleanSam(communicator, CleanSam.SET_UNMAPPED_MAPQ_TO_ZERO_ONLY));
         }
 
         if (communicator.isRun_mapping() && communicator.getMapper_to_use().equals("Bowtie 2")) {
@@ -629,6 +643,7 @@ public class RunEAGER {
                 humanancientpool.addModule(new BT2Index(communicator));
             }
             addBT2Mapping(humanancientpool);
+            humanancientpool.addModule(new CleanSam(communicator, CleanSam.SET_UNMAPPED_MAPQ_TO_ZERO_ONLY));
         }
 
         if (communicator.isRun_mapping() && communicator.getMapper_to_use().equals("BWAMem")) {
@@ -637,6 +652,7 @@ public class RunEAGER {
                 humanancientpool.addModule(new BWAIndex(communicator));
             }
             addBWAMemMapping(humanancientpool);
+            humanancientpool.addModule(new CleanSam(communicator, CleanSam.SET_UNMAPPED_MAPQ_TO_ZERO_ONLY));
         }
 
         if (communicator.isRun_mapping() && communicator.getMapper_to_use().equals("CircularMapper")) {
@@ -645,6 +661,7 @@ public class RunEAGER {
                 humanancientpool.addModule(new BWAIndex(communicator));
             }
             addCircularMapping(humanancientpool);
+            humanancientpool.addModule(new CleanSam(communicator, CleanSam.SET_UNMAPPED_MAPQ_TO_ZERO_ONLY));
         }
 
         if (communicator.isRun_complexityestimation()) {
@@ -656,14 +673,12 @@ public class RunEAGER {
         }
 
         if (communicator.isMarkdup_run()) {
-            humanancientpool.addModule(new CleanSam(communicator));
             humanancientpool.addModule(new MarkDuplicates(communicator));
         }
 
         if(communicator.isRun_mapping() && (communicator.isMarkdup_run() || communicator.isRmdup_run())){
             humanancientpool.addModule(new SamtoolsIndex(communicator, SamtoolsIndex.DEDUP));
         }
-
 
         if(communicator.isSchmutzi_run()){
             addContaminationEstimation(humanancientpool);


### PR DESCRIPTION
This should prevent as yet un-discovered problems resulting from un-mapped reads that have non zero mapping quality.

EAGER now expects there to be a tool called:

CleanSamUnmappedOnly
that takes an input sam and an output sam path, for example:

CleanSamUnmappedOnly output/AO4/4-Samtools/AO4_S0_L003_R1_001.fastq.fq.sorted.bam output/AO4/5-DeDup/AO4_S0_L003_R1_001.fastq.fq.sorted.cleaned.bam

This is a variation from the standard picard CleanSam as we don't want to also soft clip reads that extend outside the reference 
