### PR TITLE
Updated the second command for BWA aln (for unmerged paired end) to use correct file.

### DIFF
--- a/src/main/java/Modules/mapping/BWAAlign.java
+++ b/src/main/java/Modules/mapping/BWAAlign.java
@@ -78,7 +78,7 @@ public class BWAAlign extends AModule {
                 " " + this.communicator.getMapper_advanced() + " -f " + getOutputfolder() + "/" + output_stem0 + ".sai";
 
         String commandTwo = "bwa aln -t " + this.communicator.getCpucores() +
-                " " + this.communicator.getGUI_reference() + " " + this.inputfile.get(0) + " " +
+                " " + this.communicator.getGUI_reference() + " " + this.inputfile.get(1) + " " +
                 "-n " + this.communicator.getMapper_mismatches() + " -l " + this.communicator.getMapper_seedlength() +
                 " " + this.communicator.getMapper_advanced() + " -f " + getOutputfolder() + "/" + output_stem1 + ".sai";
 


### PR DESCRIPTION
previous the same input file this.inputfile.get(0) was used to generate both .sai files, which results in wrong results down the line w/o raising an exeption.
Simply changing this.inputfile.get(0) to this.inputfile.get(1) should fix this. I did not test this though!