### PR TITLE
Fix dedup problem by supporting flag for new AdapterRemoval version 2.3.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 group 'com.uni-tuebingen.de.it.eager.eager-cli'
 
-version '1.92.55'
+version '1.92.56'
 
 
 buildscript {

--- a/src/main/java/Modules/preprocessing/AdapterRemoval.java
+++ b/src/main/java/Modules/preprocessing/AdapterRemoval.java
@@ -65,6 +65,7 @@ public class AdapterRemoval extends AModule {
         cmd.add(this.communicator.getCpucores());
         cmd.add("--trimns");
         cmd.add("--trimqualities");
+        cmd.add("--preserve5p");
         cmd.add("--adapter1");
         cmd.add(this.communicator.getMerge_fwadaptor());
         cmd.add("--adapter2");
@@ -114,6 +115,7 @@ public class AdapterRemoval extends AModule {
         cmd.add(this.communicator.getCpucores());
         cmd.add("--trimns");
         cmd.add("--trimqualities");
+        cmd.add("--preserve5p");
         cmd.add("--adapter1");
         cmd.add(this.communicator.getMerge_fwadaptor());
         cmd.add("--adapter2");
@@ -155,6 +157,7 @@ public class AdapterRemoval extends AModule {
         cmd.add(this.communicator.getCpucores());
         cmd.add("--trimns");
         cmd.add("--trimqualities");
+        cmd.add("--preserve5p");
         cmd.add("--adapter1");
         cmd.add(this.communicator.getMerge_fwadaptor());
         cmd.add("--adapter2");

--- a/src/main/java/Modules/preprocessing/AdapterRemoval.java
+++ b/src/main/java/Modules/preprocessing/AdapterRemoval.java
@@ -77,6 +77,13 @@ public class AdapterRemoval extends AModule {
         cmd.add(String.valueOf(this.communicator.getMerge_min_adapter_overlap()));
         cmd.add("--collapse");
 
+        if (this.communicator.isQualityBase64()) {
+          cmd.add("--qualitybase");
+          cmd.add("64");
+          cmd.add("--qualitybase-output");
+          cmd.add("33");
+        }
+
         return cmd.toArray(new String[0]);
     }
 
@@ -119,6 +126,13 @@ public class AdapterRemoval extends AModule {
         cmd.add(String.valueOf(this.communicator.getMerge_min_adapter_overlap()));
         cmd.add("--combined-output");
 
+        if (this.communicator.isQualityBase64()) {
+          cmd.add("--qualitybase");
+          cmd.add("64");
+          cmd.add("--qualitybase-output");
+          cmd.add("33");
+        }
+
         return cmd.toArray(new String[0]);
     }
 
@@ -151,6 +165,13 @@ public class AdapterRemoval extends AModule {
         cmd.add(String.valueOf(this.communicator.getQuality_minreadquality()));
         cmd.add("--minadapteroverlap");
         cmd.add(String.valueOf(this.communicator.getMerge_min_adapter_overlap()));
+
+        if (this.communicator.isQualityBase64()) {
+          cmd.add("--qualitybase");
+          cmd.add("64");
+          cmd.add("--qualitybase-output");
+          cmd.add("33");
+        }
 
         return cmd.toArray(new String[0]);
 

--- a/src/main/java/Modules/stats/DamageProfiler.java
+++ b/src/main/java/Modules/stats/DamageProfiler.java
@@ -23,6 +23,7 @@ public class DamageProfiler extends AModule {
                     "TMPDIR",
                     getOutputfolder() + System.getProperty ("file.separator") + ".tmp");
         }
+        AModule.setEnvironmentForParameterDelete (env, "DISPLAY");
     }
 
     @Override


### PR DESCRIPTION
Fix trimming of 5 prime bases breaking dedup by supporting new version of AdapterRemoval which allows 5 prime trimming to be disabled. Add support for base64 qualities to AdapterRemoval options.

Strip DISPLAY environment var from DamageProfiler which should prevent errors caused by people running the CLI from the same terminal as the GUI.